### PR TITLE
refatore: gems adicionadas ao Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end
+
+gem 'devise', '~> 4.9.2'
+gem 'rubocop-rails', '~> 2.20.2'


### PR DESCRIPTION
Foram adicionadas as seguintes gems: 
gem 'devise', '~> 4.9.2'
gem 'rubocop-rails', '~> 2.20.2'
